### PR TITLE
Reorder install steps to fix dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,9 @@ Same as for search you can add a filter to listen.
 
 Here are some basic steps to install it on a Raspberry Pi for example:
 
-        cpanm Amazon::Dash::Button
         apt-get install libpcap0.8
         apt-get install libpcap-dev
+        cpanm Amazon::Dash::Button
 
 The git repo also provides a very basic systemctl service
 

--- a/lib/Amazon/Dash/Button.pm
+++ b/lib/Amazon/Dash/Button.pm
@@ -164,9 +164,9 @@ Same as for search you can add a filter to listen.
 
 Here are some basic steps to install it on a Raspberry Pi for example:
 
-	cpanm Amazon::Dash::Button
 	apt-get install libpcap0.8
 	apt-get install libpcap-dev
+	cpanm Amazon::Dash::Button
 
 The git repo also provides a very basic systemctl service
 


### PR DESCRIPTION
    libpcap needs to be installed before trying to install
    Amazon::Dash::Button (which uses Net::Pcap), so reorder
    the installation steps to account for this.

I was at TPC2017DC and saw your lightning talk, and it inspired me to resurrect a project I couldn't get working.  Just waiting on the Dash button to arrive!

This is my first pull request ever; so I hope I'm doing this right.  Please let me know what you think.  Thanks!