### PR TITLE
Fix systemctl install permissions

### DIFF
--- a/systemctl/Makefile
+++ b/systemctl/Makefile
@@ -7,7 +7,7 @@ status:
 	systemctl status amazon-dash-button.service
 
 install: 
-	install amazon-dash-button.service /lib/systemd/system/
+	install -m 0644 amazon-dash-button.service /lib/systemd/system/
 	systemctl daemon-reload
 	systemctl enable amazon-dash-button.service
 	systemctl restart amazon-dash-button.service


### PR DESCRIPTION
    Install new systemctl file with 0644 permissions so that
    systemd doesn't gripe about it being executable.

Hi again!  I got my Dash button today, and quickly got it working by using your excellent example scripts and your "make install" for the systemd script.  Everything works great; the only reason for this change is that systemd complains that the installed file is executable.  So I offer up a 8-character change. :)

- Mike Allard